### PR TITLE
Update the Elixir plugin

### DIFF
--- a/plugins/elixir
+++ b/plugins/elixir
@@ -1,1 +1,1 @@
-repository = https://github.com/glossia/mise-elixir.git
+repository = https://github.com/mise-plugins/mise-elixir.git

--- a/plugins/elixir
+++ b/plugins/elixir
@@ -1,1 +1,1 @@
-repository = https://github.com/asdf-vm/asdf-elixir.git
+repository = https://github.com/glossia/mise-elixir.git


### PR DESCRIPTION
I forked the Elixir plugin into the Glossia organization and fixed the issue due to the shim not being executable. Going forward, I can take care of maintaining the plugin.

## Summary

Description:

- Tool repo URL: https://github.com/glossia/mise-elixir/
- Plugin repo URL: https://github.com/glossia/mise-elixir/

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
