### PR TITLE
tuist: set first-party

### DIFF
--- a/plugins/tuist
+++ b/plugins/tuist
@@ -1,1 +1,2 @@
 repository = https://github.com/asdf-community/asdf-tuist.git
+first-party = true


### PR DESCRIPTION
gets rid of the warning below which isn't necessary because asdf-tuist is developed by tuist themselves

<img width="467" alt="Screenshot 2024-01-10 at 20 04 11" src="https://github.com/mise-plugins/registry/assets/216188/c9d2bdc3-64d2-46a3-ae35-899d607faa1f">
