### PR TITLE
feat: add gotestsum plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ See the [org's readme](https://github.com/mise-plugins) for more information.
 | Gopass                        | [trallnag/asdf-gopass](https://github.com/trallnag/asdf-gopass)                                                   |
 | GoReleaser                    | [kforsthoevel/asdf-goreleaser](https://github.com/kforsthoevel/asdf-goreleaser)                                   |
 | Goss                          | [raimon49/asdf-goss](https://github.com/raimon49/asdf-goss)                                                       |
+| gotestsum                     | [pmalek/gotestsum](https://github.com/pmalek/mise-gotestsum)                                                      |
 | GraalVM                       | [asdf-community/asdf-graalvm](https://github.com/asdf-community/asdf-graalvm)                                     |
 | Gradle                        | [rfrancis/asdf-gradle](https://github.com/rfrancis/asdf-gradle)                                                   |
 | Gradle Profiler               | [joschi/asdf-gradle-profiler](https://github.com/joschi/asdf-gradle-profiler)                                     |
@@ -514,7 +515,7 @@ See the [org's readme](https://github.com/mise-plugins) for more information.
 | pint                          | [sam-burrell/asdf-pint](https://github.com/sam-burrell/asdf-pint)                                                 |
 | pipectl                       | [pipe-cd/asdf-pipectl](https://github.com/pipe-cd/asdf-pipectl)                                                   |
 | pipelight                     | [kogeletey/asdf-pipelight](https://github.com/kogeletey/asdf-pipelight)                                           |
-| pipenv                        | [mise-plugins/mise-pipenv](https://github.com/mise-plugins/mise-pipenv)                                             |
+| pipenv                        | [mise-plugins/mise-pipenv](https://github.com/mise-plugins/mise-pipenv)                                           |
 | pipx                          | [yozachar/asdf-pipx](https://github.com/yozachar/asdf-pipx)                                                       |
 | pivnet                        | [vmware-tanzu/tanzu-plug-in-for-asdf](https://github.com/vmware-tanzu/tanzu-plug-in-for-asdf)                     |
 | Please                        | [asdf-community/asdf-please](https://github.com/asdf-community/asdf-please)                                       |

--- a/plugins/gotestsum
+++ b/plugins/gotestsum
@@ -1,0 +1,1 @@
+repository = https://github.com/pmalek/mise-gotestsum.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/gotestyourself/gotestsum
- Plugin repo URL: https://github.com/pmalek/mise-gotestsum

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to mise-plugins! -->
