### PR TITLE
feat: add asdf-coder

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ See the [org's readme](https://github.com/mise-plugins) for more information.
 | CocoaPods                     | [ronnnnn/asdf-cocoapods](https://github.com/ronnnnn/asdf-cocoapods)                                               |
 | Codefresh                     | [gurukulkarni/asdf-codefresh](https://github.com/gurukulkarni/asdf-codefresh)                                     |
 | CodeQL                        | [bored-engineer/asdf-codeql](https://github.com/bored-engineer/asdf-codeql)                                       |
+| Coder                         | [mise-plugins/asdf-coder](https://github.com/mise-plugins/asdf-coder)                                             |
 | Colima                        | [CrouchingMuppet/asdf-colima](https://github.com/CrouchingMuppet/asdf-colima)                                     |
 | Conan                         | [amrox/asdf-pyapp](https://github.com/amrox/asdf-pyapp)                                                           |
 | Concourse                     | [mattysweeps/asdf-concourse](https://github.com/mattysweeps/asdf-concourse)                                       |

--- a/plugins/coder
+++ b/plugins/coder
@@ -1,0 +1,1 @@
+repository = https://github.com/mise-plugins/asdf-coder


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://coder.com/
- Plugin repo URL: https://github.com/mise-plugins/asdf-coder

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/coder`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to mise-plugins! -->
