### PR TITLE
feat: add sentry-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ See the [org's readme](https://github.com/mise-plugins) for more information.
 | semtag                        | [junminahn/asdf-semtag](https://github.com/junminahn/asdf-semtag)                                                 |
 | semver                        | [mathew-fleisch/asdf-semver](https://github.com/mathew-fleisch/asdf-semver)                                       |
 | Sentinel                      | [asdf-community/asdf-hashicorp](https://github.com/asdf-community/asdf-hashicorp)                                 |
+| sentry-cli                    | [MacPaw/asdf-sentry-cli](https://github.com/MacPaw/asdf-sentry-cli)                                               |
 | Serf                          | [asdf-community/asdf-hashicorp](https://github.com/asdf-community/asdf-hashicorp)                                 |
 | serverless                    | [pdemagny/asdf-serverless](https://github.com/pdemagny/asdf-serverless)                                           |
 | setup-envtest                 | [pmalek/mise-setup-envtest](https://github.com/pmalek/mise-setup-envtest)                                         |

--- a/plugins/sentry-cli
+++ b/plugins/sentry-cli
@@ -1,0 +1,1 @@
+repository = https://github.com/MacPaw/asdf-sentry-cli


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/getsentry/sentry-cli
- Plugin repo URL: https://github.com/MacPaw/asdf-sentry-cli

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to mise-plugins! -->
