### PR TITLE
feat: add powerpipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ See the [org's readme](https://github.com/mise-plugins) for more information.
 | Popeye                        | [nlamirault/asdf-popeye](https://github.com/nlamirault/asdf-popeye)                                               |
 | Postgres                      | [smashedtoatoms/asdf-postgres](https://github.com/smashedtoatoms/asdf-postgres)                                   |
 | powerline-go                  | [dex4er/asdf-powerline-go](https://github.com/dex4er/asdf-powerline-go)                                           |
+| powerpipe                     | [jc00ke/asdf-powerpipe](https://github.com/jc00ke/asdf-powerpipe)                                                 |
 | PowerShell                    | [daveneeley/asdf-powershell-core](https://github.com/daveneeley/asdf-powershell-core)                             |
 | pre-commit                    | [jonathanmorley/asdf-pre-commit](https://github.com/jonathanmorley/asdf-pre-commit)                               |
 | promtool                      | [asdf-community/asdf-promtool](https://github.com/asdf-community/asdf-promtool)                                   |

--- a/plugins/powerpipe
+++ b/plugins/powerpipe
@@ -1,0 +1,1 @@
+repository = https://github.com/jc00ke/asdf-powerpipe.git


### PR DESCRIPTION
## Summary

Description: Adding turbot's `powerpipe` which was recently separated from `steampipe` which is already listed in this registry.

- Tool repo URL: https://github.com/turbot/powerpipe
- Plugin repo URL: https://github.com/jc00ke/asdf-powerpipe

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [ ] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_
