### PR TITLE
feat: add danger-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ See the [org's readme](https://github.com/mise-plugins) for more information.
 | cyclonedx                     | [xeedio/asdf-cyclonedx](https://github.com/xeedio/asdf-cyclonedx)                                                 |
 | D (DMD)                       | [sylph01/asdf-dmd](https://github.com/sylph01/asdf-dmd)                                                           |
 | dagger                        | [virtualstaticvoid/asdf-dagger](https://github.com/virtualstaticvoid/asdf-dagger)                                 |
+| danger-js                     | [MontakOleg/asdf-danger-js](https://github.com/MontakOleg/asdf-danger-js.git)                                     |
 | dapr                          | [asdf-community/asdf-dapr-cli](https://github.com/asdf-community/asdf-dapr-cli.git)                               |
 | Dart                          | [PatOConnor43/asdf-dart](https://github.com/PatOConnor43/asdf-dart)                                               |
 | Dasel                         | [asdf-community/asdf-dasel](https://github.com/asdf-community/asdf-dasel)                                         |

--- a/plugins/danger-js
+++ b/plugins/danger-js
@@ -1,0 +1,1 @@
+repository = https://github.com/MontakOleg/asdf-danger-js.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/danger/danger-js
- Plugin repo URL: https://github.com/MontakOleg/asdf-danger-js

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to mise-plugins! -->
