### PR TITLE
feat: add egnor/arduino-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ See the [org's readme](https://github.com/mise-plugins) for more information.
 | apollo-ios-cli                | [MacPaw/asdf-apollo-ios-cli](https://github.com/MacPaw/asdf-apollo-ios-cli)                                       |
 | Apollo Router                 | [safx/asdf-apollo-router](https://github.com/safx/asdf-apollo-router)                                             |
 | arc                           | [ORCID/asdf-arc](https://github.com/ORCID/asdf-arc)                                                               |
+| Arduino CLI                   | [egnor/asdf-arduino-cli](https://github.com/egnor/asdf-arduino-cli)                                               |
 | argo                          | [sudermanjr/asdf-argo](https://github.com/sudermanjr/asdf-argo)                                                   |
 | argo-rollouts                 | [abatilo/asdf-argo-rollouts](https://github.com/abatilo/asdf-argo-rollouts)                                       |
 | argocd                        | [beardix/asdf-argocd](https://github.com/beardix/asdf-argocd)                                                     |

--- a/plugins/arduino-cli
+++ b/plugins/arduino-cli
@@ -1,0 +1,1 @@
+repository = https://github.com/egnor/asdf-arduino-cli


### PR DESCRIPTION
## Summary

Description: Arduino CLI

- Tool repo URL: https://github.com/arduino/arduino-cli
- Plugin repo URL: https://github.com/egnor/asdf-arduino-cli

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to mise-plugins! -->
