### PR TITLE
feat: aapt2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ See the [org's readme](https://github.com/mise-plugins) for more information.
 | .Net                          | [hensou/asdf-dotnet](https://github.com/hensou/asdf-dotnet)                                                       |
 | .Net Core                     | [emersonsoares/asdf-dotnet-core](https://github.com/emersonsoares/asdf-dotnet-core)                               |
 | 1password-cli                 | [NeoHsu/asdf-1password-cli](https://github.com/NeoHsu/asdf-1password-cli)                                         |
+| AAPT2                         | [ronnnnn/asdf-aapt2](https://github.com/ronnnnn/asdf-aapt2)                                                       |
 | act                           | [gr1m0h/asdf-act](https://github.com/gr1m0h/asdf-act)                                                             |
 | action-validator              | [mpalmer/action-validator](https://github.com/mpalmer/action-validator)                                           |
 | actionlint                    | [crazy-matt/asdf-actionlint](https://github.com/crazy-matt/asdf-actionlint)                                       |

--- a/plugins/aapt2
+++ b/plugins/aapt2
@@ -1,0 +1,1 @@
+repository = https://github.com/ronnnnn/asdf-aapt2.git


### PR DESCRIPTION
## Summary

Add [AAPT2 (Android Asset Packaging Tool)](https://developer.android.com/tools/aapt2) plugin.

Description:

- Tool repo URL: https://maven.google.com/web/index.html#com.android.tools.build:aapt2
- Plugin repo URL: https://github.com/ronnnnn/asdf-aapt2

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to mise-plugins! -->
