### PR TITLE
feat: New Atlas Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ See the [org's readme](https://github.com/mise-plugins) for more information.
 | asciidoctorj                  | [gliwka/asdf-asciidoctorj](https://github.com/gliwka/asdf-asciidoctorj)                                           |
 | asdf-plugin-manager           | [asdf-community/asdf-plugin-manager](https://github.com/asdf-community/asdf-plugin-manager)                       |
 | assh                          | [zekker6/asdf-assh](https://github.com/zekker6/asdf-assh)                                                         |
-| atlas                         | [pbr0ck3r/asdf-atlas](https://github.com/pbr0ck3r/asdf-atlas)                                                     |
+| atlas                         | [komi1230/asdf-atlas](https://github.com/komi1230/asdf-atlas)                                                     |
 | auto-doc                      | [looztra/asdf-auto-doc](https://github.com/looztra/asdf-auto-doc)                                                 |
 | aws-copilot                   | [NeoHsu/asdf-copilot](https://github.com/NeoHsu/asdf-copilot)                                                     |
 | aws-amplify-cli               | [LozanoMatheus/asdf-aws-amplify-cli](https://github.com/LozanoMatheus/asdf-aws-amplify-cli)                       |

--- a/plugins/atlas
+++ b/plugins/atlas
@@ -1,1 +1,1 @@
-repository = https://github.com/pbr0ck3r/asdf-atlas.git
+repository = https://github.com/komi1230/asdf-atlas.git


### PR DESCRIPTION
## Summary

Current repository of [atlas](https://atlasgo.io/) is [pbr0ck3r/asdf-atlas](https://github.com/pbr0ck3r/asdf-atlas) but it seems to be deleted now.
So I created new [asdf-atlas](https://github.com/komi1230/asdf-atlas).

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to mise-plugins! -->
