### PR TITLE
Add virtualOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,6 +743,7 @@ See the [org's readme](https://github.com/mise-plugins) for more information.
 | vhs                           | [chessmango/asdf-vhs](https://github.com/chessmango/asdf-vhs)                                                     |
 | Viddy                         | [ryodocx/asdf-viddy](https://github.com/ryodocx/asdf-viddy)                                                       |
 | Vim                           | [tsuyoshicho/asdf-vim](https://github.com/tsuyoshicho/asdf-vim)                                                   |
+| VirtualOS                     | [tuist/asdf-virtualos](https://github.com/tuist/asdf-virtualos)                                                   |
 | vlt                           | [asdf-community/asdf-hashicorp](https://github.com/asdf-community/asdf-hashicorp)                                 |
 | vultr-cli                     | [ikuradon/asdf-vultr-cli](https://github.com/ikuradon/asdf-vultr-cli)                                             |
 | watchexec                     | [nyrst/asdf-watchexec](https://github.com/nyrst/asdf-watchexec)                                                   |

--- a/plugins/virtualos
+++ b/plugins/virtualos
@@ -1,0 +1,1 @@
+repository = https://github.com/tuist/asdf-virtualos.git


### PR DESCRIPTION
## Summary

Description: I'm adding virtualOS to the list of official plugins. virtualOS is a CLI tool like Docker but to virtualize macOS environments.

- Tool repo URL: https://github.com/tuist/virtualos
- Plugin repo URL: https://github.com/tuist/asdf-virtualos

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
