### PR TITLE
feat: add license-plist

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ See the [org's readme](https://github.com/mise-plugins) for more information.
 | Levant                        | [asdf-community/asdf-hashicorp](https://github.com/asdf-community/asdf-hashicorp)                                 |
 | LFE                           | [asdf-community/asdf-lfe](https://github.com/asdf-community/asdf-lfe)                                             |
 | libsql-server                 | [jonasb/asdf-libsql-server](https://github.com/jonasb/asdf-libsql-server)                                         |
+| license-plist                 | [MacPaw/asdf-license-plist](https://github.com/MacPaw/asdf-license-plist)                                         |
 | Lima                          | [CrouchingMuppet/asdf-lima](https://github.com/CrouchingMuppet/asdf-lima)                                         |
 | Link (system tools)           | [asdf-community/asdf-link](https://github.com/asdf-community/asdf-link)                                           |
 | Linkerd                       | [kforsthoevel/asdf-linkerd](https://github.com/kforsthoevel/asdf-linkerd)                                         |

--- a/plugins/license-plist
+++ b/plugins/license-plist
@@ -1,0 +1,1 @@
+repository = https://github.com/MacPaw/asdf-license-plist.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/mono0926/LicensePlist
- Plugin repo URL: https://github.com/MacPaw/asdf-license-plist

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to asdf-plugins! -->
