### PR TITLE
feat: add swift-package-list

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@ See the [org's readme](https://github.com/mise-plugins) for more information.
 | svu                           | [asdf-community/asdf-svu](https://github.com/asdf-community/asdf-svu)                                             |
 | swag                          | [behoof4mind/asdf-swag](https://github.com/behoof4mind/asdf-swag)                                                 |
 | Swift                         | [fcrespo82/asdf-swift](https://github.com/fcrespo82/asdf-swift)                                                   |
+| swift-package-list            | [MacPaw/asdf-swift-package-list](https://github.com/MacPaw/asdf-swift-package-list)                               |
 | SwiftFormat                   | [younke/asdf-swiftformat](https://github.com/younke/asdf-swiftformat)                                             |
 | SwiftGen                      | [younke/asdf-swiftgen](https://github.com/younke/asdf-swiftgen)                                                   |
 | Swiftlint                     | [klundberg/asdf-swiftlint](https://github.com/klundberg/asdf-swiftlint)                                           |

--- a/plugins/swift-package-list
+++ b/plugins/swift-package-list
@@ -1,0 +1,1 @@
+repository = https://github.com/MacPaw/asdf-swift-package-list.git


### PR DESCRIPTION
## Summary

Description:

- Tool repo URL: https://github.com/FelixHerrmann/swift-package-list
- Plugin repo URL: https://github.com/MacPaw/asdf-swift-package-list

## Checklist

- [x] Format with `scripts/format.bash`
- [x] Test locally with `scripts/test_plugin.bash --file plugins/<your_new_plugin_name>`
- [x] Your plugin CI tests are green
  - _Tip: use the `plugin_test` action from [asdf-actions](https://github.com/asdf-vm/actions) in your plugin CI_

<!-- Thank you for contributing to mise-plugins! -->
